### PR TITLE
Refactor toml dependencies keys to reflect modId

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -14,13 +14,13 @@ authors="Corgi Taco"
 description='''
 A minecraft mod adding new Lunar Events!
 '''
-[[dependencies.examplemod]]
+[[dependencies.enhancedcelestials]]
     modId="forge"
     mandatory=true
     versionRange="[33.0.22,)"
     ordering="NONE"
     side="BOTH"
-[[dependencies.examplemod]]
+[[dependencies.enhancedcelestials]]
     modId="minecraft"
     mandatory=true
     versionRange="[1.16.2,)"


### PR DESCRIPTION
A simple change in the [[dependencies.key]] declaration which reflects the actual modId of the mod. This will help ServerPackCreator identify the sideness in future upates.

For reference: https://github.com/Griefed/ServerPackCreator/issues/70

Cheers,
Griefed